### PR TITLE
Chording

### DIFF
--- a/src/main/java/org/example/minesweeper/GameLogic.java
+++ b/src/main/java/org/example/minesweeper/GameLogic.java
@@ -124,6 +124,50 @@ public class GameLogic {
         return true;
     }
 
+    public void chordCell(int row, int col) {
+        Cell cell = grid[row][col];
+        if (cell.isRevealed() && (cell.getNeighborMines() == countNeighborFlags(row, col))) {
+            for (int[] coord : getHiddenCells(row, col)) {
+                if (coord != null) {
+                    revealCell(coord[0], coord[1]);
+                }
+            }
+        } else {
+            return;
+        }
+    }
+    private int countNeighborFlags(int row, int col) {
+        int flags = 0;
+        int rows = grid.length;
+        int cols = grid[0].length;
+        int[] dr = {-1, -1, -1, 0, 0, 1, 1, 1};
+        int[] dc = {-1, 0, 1, -1, 1, -1, 0, 1};
+        for (int i = 0; i < 8; i++) {
+            int neighborRow = row + dr[i];
+            int neighborCol = col + dc[i];
+            if (neighborRow >= 0 && neighborRow < rows && neighborCol >= 0 && neighborCol < cols) {
+                if (grid[neighborRow][neighborCol].isFlagged()) flags++;
+            }
+        }
+        return flags;
+    }
+    private int[][] getHiddenCells(int row, int col) {
+        int[][] arr =  new int[8][];
+        int rows = grid.length;
+        int cols = grid[0].length;
+        int[] dr = {-1, -1, -1, 0, 0, 1, 1, 1};
+        int[] dc = {-1, 0, 1, -1, 1, -1, 0, 1};
+        for (int i = 0; i < 8; i++) {
+            int neighborRow = row + dr[i];
+            int neighborCol = col + dc[i];
+            if (neighborRow >= 0 && neighborRow < rows && neighborCol >= 0 && neighborCol < cols) {
+                if (grid[neighborRow][neighborCol].isHidden()) {
+                    arr[i] = new int[]{neighborRow, neighborCol};
+                }
+            }
+        }
+        return arr;
+    }
 
     private void revealEmptyNeighbors(int row, int col) {
         for (int di = -1; di <= 1; di++) {

--- a/src/main/java/org/example/minesweeper/MinesweeperController.java
+++ b/src/main/java/org/example/minesweeper/MinesweeperController.java
@@ -105,12 +105,19 @@ public class MinesweeperController implements Initializable {
 
                 final int row = i;
                 final int col = j;
+                Cell cell = gameLogic.getCell(row, col);
 
                 button.setOnMouseClicked(event -> {
                     if (event.getButton() == MouseButton.PRIMARY) {
-                        if (gameLogic.revealCell(row, col)) {
+                        if (cell.isRevealed()) {
+                            gameLogic.chordCell(row, col);
                             updateDisplay();
                             checkGameEnd();
+                        } else {
+                            if (gameLogic.revealCell(row, col)) {
+                                updateDisplay();
+                                checkGameEnd();
+                            }
                         }
                     } else if (event.getButton() == MouseButton.SECONDARY) {
                         gameLogic.toggleFlag(row, col);


### PR DESCRIPTION
Chording allows players to reveal all hidden neighboring cells around a revealed cell if the number of flagged neighboring cells matches the number of mines. I added this implementation to the code.

### Game Logic Additions:
* Added a new method `chordCell` in `GameLogic.java` to handle the chording functionality. It checks if the conditions for chording are met and reveals neighboring hidden cells accordingly. Used helper methods `countNeighborFlags` and `getHiddenCells`

### Controller Updates:
* Modified `createGameGrid` in `MinesweeperController.java` to add support for chording when a revealed cell is clicked with the mouse. The controller now calls `chordCell` and updates the display accordingly.